### PR TITLE
Act as stream a

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,12 +56,4 @@ path = "src/main.rs"
 
 [[bin]]
 name = "scan-devices"
-path = "src/bin/scan_devices.rs"
-
-[[bin]]
-name = "capture-keys"
-path = "src/bin/capture_keys.rs"
-
-[[bin]]
-name = "send-key"
-path = "src/bin/send_key.rs" 
+path = "src/bin/scan_devices.rs" 

--- a/src/device_scanner.rs
+++ b/src/device_scanner.rs
@@ -1,5 +1,5 @@
 use hidapi::{HidApi, DeviceInfo as HidDeviceInfo};
-use log::{debug, info, warn};
+use log::{debug, info};
 use crate::{DeviceInfo, DurgodError};
 use anyhow::Result;
 
@@ -19,7 +19,7 @@ impl DeviceScanner {
     pub fn scan_all_devices(&self) -> Result<Vec<ScannedDevice>> {
         info!("Scanning for all HID devices...");
         
-        let devices = self.api.device_list()
+        let devices: Vec<ScannedDevice> = self.api.device_list()
             .map(|device_info| ScannedDevice::from_hid_device_info(device_info))
             .collect();
         
@@ -74,13 +74,11 @@ impl DeviceScanner {
         let devices: Vec<ScannedDevice> = self.api.device_list()
             .filter(|device| {
                 let manufacturer = device.manufacturer_string()
-                    .unwrap_or_else(|| Some("".to_string()))
-                    .unwrap_or_else(|| "".to_string())
+                    .unwrap_or("")
                     .to_lowercase();
                 
                 let product = device.product_string()
-                    .unwrap_or_else(|| Some("".to_string()))
-                    .unwrap_or_else(|| "".to_string())
+                    .unwrap_or("")
                     .to_lowercase();
                 
                 manufacturer.contains(&search_lower) || product.contains(&search_lower)
@@ -136,13 +134,11 @@ impl DeviceScanner {
         
         // For now, we'll be more permissive and include devices that might be keyboards
         let manufacturer = device.manufacturer_string()
-            .unwrap_or_else(|| Some("".to_string()))
-            .unwrap_or_else(|| "".to_string())
+            .unwrap_or("")
             .to_lowercase();
         
         let product = device.product_string()
-            .unwrap_or_else(|| Some("".to_string()))
-            .unwrap_or_else(|| "".to_string())
+            .unwrap_or("")
             .to_lowercase();
         
         // Check for keyboard-related terms
@@ -160,15 +156,15 @@ impl DeviceScanner {
         };
         
         let manufacturer = device.get_manufacturer_string()
-            .unwrap_or_else(|_| Some("Unknown".to_string()))
+            .unwrap_or(Some("Unknown".to_string()))
             .unwrap_or_else(|| "Unknown".to_string());
         
         let product = device.get_product_string()
-            .unwrap_or_else(|_| Some("Unknown".to_string()))
+            .unwrap_or(Some("Unknown".to_string()))
             .unwrap_or_else(|| "Unknown".to_string());
         
         let serial = device.get_serial_number_string()
-            .unwrap_or_else(|_| Some("Unknown".to_string()))
+            .unwrap_or(Some("Unknown".to_string()))
             .unwrap_or_else(|| "Unknown".to_string());
         
         Ok(Some(DetailedDeviceInfo {
@@ -203,9 +199,9 @@ impl ScannedDevice {
         Self {
             vendor_id: info.vendor_id(),
             product_id: info.product_id(),
-            manufacturer: info.manufacturer_string().unwrap_or(None),
-            product: info.product_string().unwrap_or(None),
-            serial_number: info.serial_number().unwrap_or(None),
+            manufacturer: info.manufacturer_string().map(|s| s.to_string()),
+            product: info.product_string().map(|s| s.to_string()),
+            serial_number: info.serial_number().map(|s| s.to_string()),
             interface_number: info.interface_number(),
             usage_page: info.usage_page(),
             usage: info.usage(),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -64,7 +64,25 @@ impl From<hidapi::HidError> for DurgodError {
                 DurgodError::CommunicationError("Unknown HID API error".to_string())
             }
             hidapi::HidError::FromWideCharError { wide_char } => {
-                DurgodError::CommunicationError(format!("String conversion error: {}", wide_char))
+                DurgodError::CommunicationError(format!("String conversion error: {:?}", wide_char))
+            }
+            hidapi::HidError::InitializationError => {
+                DurgodError::HidInitError("HID API initialization failed".to_string())
+            }
+            hidapi::HidError::InvalidZeroSizeData => {
+                DurgodError::CommunicationError("Invalid zero-size data".to_string())
+            }
+            hidapi::HidError::IncompleteSendError { sent, all } => {
+                DurgodError::CommunicationError(format!("Incomplete send: {} of {} bytes", sent, all))
+            }
+            hidapi::HidError::SetBlockingModeError { mode } => {
+                DurgodError::CommunicationError(format!("Failed to set blocking mode: {}", mode))
+            }
+            hidapi::HidError::OpenHidDeviceWithDeviceInfoError { device_info } => {
+                DurgodError::DeviceNotFound(format!("Failed to open device: {:?}", device_info))
+            }
+            hidapi::HidError::IoError { error } => {
+                DurgodError::CommunicationError(format!("I/O error: {}", error))
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use hidapi::HidApi;
-use log::{debug, info, warn, error};
+use log::{debug, info};
 use std::time::Duration;
 
 pub mod errors;


### PR DESCRIPTION
Fix Rust compilation issues by updating `hidapi` error handling, string conversions, and `Cargo.toml`.

The `hidapi` library updated to v2.6.3, which introduced breaking changes in its error types and string handling. This PR updates the code to be compatible with the new API, resolves type inference issues, and removes references to non-existent binaries in `Cargo.toml` to ensure a clean build.

---

[Open in Web](https://cursor.com/agents?id=bc-9435af58-4641-4b63-b82e-2f1f85a60b3f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9435af58-4641-4b63-b82e-2f1f85a60b3f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)